### PR TITLE
Update manifest with missing update_catalog property

### DIFF
--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -4,6 +4,7 @@
   "name": "ejbca-k8s-csr-signer",
   "status": "production",
   "link_github": true,
+  "update_catalog": true,
   "platform_matrix": "linux/arm64,linux/amd64,linux/s390x,linux/ppc64le",
   "description": "An implementation of the Kubernetes CSR signing API that routes Certificate Signing Requests from the cluster to the EJBCA Enrollment API",
   "support_level": "kf-community",


### PR DESCRIPTION
## Describe your changes
Update the integration-manifest.json with the missing "update_catalog" property set to true. This fixes the broken workflow job: "Set workflow variables from integration manifest"

## How has this been tested?

Tested in personal fork. Note the job will still fail at the "Update catalog entry" due to the token required is only available at the keyfactor organization level to gain access to write to the Integration CAtalog

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [X] I have performed a self-review of my code
- [X] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](CONTRIBUTING.md).
